### PR TITLE
Fix emoji reactions

### DIFF
--- a/padle/view/padle_scroll_view.py
+++ b/padle/view/padle_scroll_view.py
@@ -58,11 +58,12 @@ class PADleScrollViewState(ViewStateBase):
             'reaction_list': self.reaction_list,
             'current_day': self.current_day,
             'cur_monster': self.monster.monster_id,
+            'guesses': self.cur_day_guesses,
         })
         return ret
 
     @classmethod
-    async def deserialize(dbcog, _user_config: UserConfig, ims: dict, all_guesses):
+    async def deserialize(cls, dbcog, _user_config: UserConfig, ims: dict, today_guesses):
         original_author_id = ims['original_author_id']
         menu_type = ims['menu_type']
         reaction_list = ims['reaction_list']
@@ -70,10 +71,9 @@ class PADleScrollViewState(ViewStateBase):
         current_day = ims['current_day']
         cur_monster = ims['cur_monster']
         monster = dbcog.get_monster(int(cur_monster))
-        cur_day_guesses = all_guesses[current_day]
         return PADleScrollViewState(original_author_id, menu_type, "", current_page=current_page,
                                     current_day=current_day, reaction_list=reaction_list, dbcog=dbcog,
-                                    cur_day_guesses=cur_day_guesses, monster=monster)
+                                    cur_day_guesses=today_guesses, monster=monster)
 
 class PADleScrollView:
     VIEW_TYPE = 'PADleScroll'


### PR DESCRIPTION
The problem was that at some point you changed which emojis were being used, but you only changed it in one place. So the initial reaction list was triangles, but menu2 wanted to respond to double arrows, and that disconnect was breaking it. I unified the set of emojis, and now it's working.

There is one small issue which is that bots cannot remove their own reactions in DMs. As a small workaround to this, I propose allowing PADle to be played by anyone who has Administrator privileges in a server. This would allow people to play PADle in private servers and have better emoji-removal UX.

btw I updated the behavior of hardreset to always make the monster Tsubaki because I accidentally won my game and then I couldn't test anymore and hardreset didn't work because the monsters.txt wasn't imported into my actual directory or something. I propose making the monster list a python file with the list of monsters an array of integers instead of a text file, so that it gets imported properly.